### PR TITLE
Add Discord integration with role-based permissions

### DIFF
--- a/DISCORD.md
+++ b/DISCORD.md
@@ -51,9 +51,16 @@ Add to your `config/config.json`:
 ```json
 {
   "discordToken": "YOUR_BOT_TOKEN_HERE",
-  "discordChannels": ["CHANNEL_ID_1", "CHANNEL_ID_2"]
+  "discordChannels": ["CHANNEL_ID_1", "CHANNEL_ID_2"],
+  "discordAdminRoles": ["DJ", "Music Admin", "Admin"]
 }
 ```
+
+**Admin Permissions:**
+- `discordChannels`: Channels where bot responds to commands
+- `discordAdminRoles`: Role names or IDs that can use admin commands (setvolume, flush, etc.)
+- Users with these roles can use admin commands in ANY allowed channel
+- Discord uses **role-based permissions** (more flexible than Slack's channel-based approach)
 
 ### 5. Start the Bot
 
@@ -75,15 +82,24 @@ You should see:
 
 All commands work the same as in Slack:
 
+**Regular Commands** (anyone):
 ```
 add bohemian rhapsody
 bestof queen
-pause
-play
-volume 50
 gong
 vote
 list
+current
+```
+
+**Admin Commands** (requires role in `discordAdminRoles`):
+```
+pause
+play
+setvolume 50
+flush
+next
+remove
 ```
 
 ### Mentions

--- a/DISCORD.md
+++ b/DISCORD.md
@@ -1,0 +1,149 @@
+# Discord Integration for SlackONOS
+
+SlackONOS now supports Discord alongside Slack! You can run both simultaneously or just Discord.
+
+## Features
+
+- ✅ All music commands work on Discord
+- ✅ Voting system (gong, vote, flush)
+- ✅ Shared Sonos queue between Slack and Discord
+- ✅ Emoji reactions support
+- ✅ Multi-channel support
+
+## Setup
+
+### 1. Create Discord Bot
+
+1. Go to https://discord.com/developers/applications
+2. Click "New Application"
+3. Give it a name (e.g., "SlackONOS")
+4. Go to "Bot" section
+5. Click "Add Bot"
+6. Under "Privileged Gateway Intents", enable:
+   - ✅ Message Content Intent
+   - ✅ Server Members Intent (optional)
+7. Copy the bot token
+
+### 2. Invite Bot to Server
+
+1. Go to "OAuth2" → "URL Generator"
+2. Select scopes:
+   - ✅ `bot`
+3. Select bot permissions:
+   - ✅ Send Messages
+   - ✅ Read Messages/View Channels
+   - ✅ Read Message History
+   - ✅ Add Reactions
+4. Copy the generated URL and open in browser
+5. Select your server and authorize
+
+### 3. Get Channel IDs
+
+1. Enable Developer Mode in Discord:
+   - User Settings → Advanced → Developer Mode
+2. Right-click on the channel(s) you want the bot to work in
+3. Click "Copy Channel ID"
+
+### 4. Configure SlackONOS
+
+Add to your `config/config.json`:
+
+```json
+{
+  "discordToken": "YOUR_BOT_TOKEN_HERE",
+  "discordChannels": ["CHANNEL_ID_1", "CHANNEL_ID_2"]
+}
+```
+
+### 5. Start the Bot
+
+```bash
+npm install  # Installs discord.js
+node index.js
+```
+
+You should see:
+```
+✅ Slack connection established.
+🎮 Discord client connecting...
+✅ Discord bot logged in as SlackONOS#1234
+```
+
+## Usage
+
+### Commands
+
+All commands work the same as in Slack:
+
+```
+add bohemian rhapsody
+bestof queen
+pause
+play
+volume 50
+gong
+vote
+list
+```
+
+### Mentions
+
+You can mention the bot or just use commands directly:
+```
+@SlackONOS add everlong
+add everlong
+```
+
+### Platform-Specific Behavior
+
+- **Slack:** Uses reactions for interactive votes
+- **Discord:** Uses emoji reactions (coming soon!)
+- **Shared Queue:** Music added from either platform goes to same Sonos queue
+
+## Troubleshooting
+
+### Bot doesn't respond
+
+- Check bot has "Read Messages" permission in channel
+- Verify channel ID is in `discordChannels` array
+- Check logs for connection errors
+
+### "Missing Access" error
+
+- Ensure bot was invited with correct permissions
+- Re-invite bot with updated permission URL
+
+### Bot connects but doesn't see messages
+
+- Enable "Message Content Intent" in Discord Developer Portal
+- Bot → Privileged Gateway Intents → Message Content Intent
+
+## Running Slack + Discord Simultaneously
+
+Simply configure both:
+- `slackAppToken`, `token` for Slack
+- `discordToken`, `discordChannels` for Discord
+
+The bot will connect to both and share the same Sonos queue!
+
+## Discord-Only Mode
+
+If you only want Discord (no Slack):
+- Comment out Slack validation in `index.js` startup sequence
+- Or just don't configure Slack tokens (will log warning but continue)
+
+## Architecture
+
+```
+Discord Gateway
+    ↓
+discord.js module
+    ↓
+processInput() ← Shared command handler
+    ↓
+_slackMessage() (auto-detects platform)
+    ↓
+Discord Channel / Slack Channel
+```
+
+All business logic (Spotify, Sonos, voting) is shared between platforms!

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 
 
 # SlackONOS
-**Slack / Sonos / Spotify / Node.js - Control Sonos through #Slack**
+**Slack / Discord / Sonos / Spotify / Node.js - Control Sonos through Slack & Discord**
 
+Now supports both **Slack** and **Discord**! Run them simultaneously or use Discord-only mode.
 
 *Screenshot*
 
@@ -16,13 +17,22 @@
 
 **What is it?**
 
-It´s a #slack-bot that control Sonos (and spotify). Highly democratic bot :)
-Uses https://github.com/bencevans/node-sonos to controll Sonos.
+A chat bot that controls Sonos speakers (with Spotify integration) through **Slack** and **Discord**. Highly democratic bot with community voting features!
+
+Uses https://github.com/bencevans/node-sonos to control Sonos.
+
+**Platforms:**
+- ✅ **Slack** - Full Socket Mode support with channel-based admin permissions
+- ✅ **Discord** - Full support with role-based admin permissions  
+- 🎵 **Shared Queue** - Both platforms control the same Sonos speaker
+- 🗳️ **Democratic Controls** - Gong and vote systems work across platforms
+
+📖 **[Discord Setup Guide](DISCORD.md)** - Complete setup instructions for Discord integration
 
 **What do I need in order to get it to work?**
 
 1: A Sonos player (configured with Spotify).  
-2: A slack-bot configured in #Slack  
+2: A Slack bot configured in #Slack **OR** a Discord bot  
 3: A server running node.js  
 4: Know the IP of your Sonos. Preferably a static one.  
 5: A valid spotify account with Client ID & Client Secret. Head over to:   https://developer.spotify.com/dashboard/applications to set it up. Enter the data in the config.json file.  

--- a/config/config.json.example
+++ b/config/config.json.example
@@ -12,6 +12,7 @@
     "token": "SLACK:APPTOKEN",
     "discordToken": "DISCORD:BOT:TOKEN",
     "discordChannels": ["DISCORD_CHANNEL_ID_1", "DISCORD_CHANNEL_ID_2"],
+    "discordAdminRoles": ["DJ", "Music Admin", "Admin"],
     "webPort" : "8080",
     "ipAddress" : "IP_HOST",
     "market" : "US",

--- a/config/config.json.example
+++ b/config/config.json.example
@@ -10,6 +10,8 @@
     "legacySlackToken" : "SLACK:TOKEN",
     "slackAppToken" : "SLACK:APPTOKEN",
     "token": "SLACK:APPTOKEN",
+    "discordToken": "DISCORD:BOT:TOKEN",
+    "discordChannels": ["DISCORD_CHANNEL_ID_1", "DISCORD_CHANNEL_ID_2"],
     "webPort" : "8080",
     "ipAddress" : "IP_HOST",
     "market" : "US",

--- a/discord.js
+++ b/discord.js
@@ -1,0 +1,115 @@
+'use strict'
+
+const { Client, GatewayIntentBits, Events } = require('discord.js');
+const logger = require('./logger.js');
+
+/**
+ * Discord client module for SlackONOS
+ * Handles Discord Gateway connection and message events
+ */
+
+let discordClient = null;
+let botUserId = null;
+
+async function initializeDiscord(config, messageHandler) {
+    if (!config.discordToken) {
+        logger.warn('Discord token not configured - Discord integration disabled');
+        return null;
+    }
+
+    try {
+        // Create Discord client with required intents
+        discordClient = new Client({
+            intents: [
+                GatewayIntentBits.Guilds,
+                GatewayIntentBits.GuildMessages,
+                GatewayIntentBits.MessageContent,
+                GatewayIntentBits.GuildMessageReactions
+            ]
+        });
+
+        // Ready event - bot is connected
+        discordClient.once(Events.ClientReady, (client) => {
+            botUserId = client.user.id;
+            logger.info(`✅ Discord bot logged in as ${client.user.tag}`);
+            logger.info(`   Bot user ID: ${botUserId}`);
+        });
+
+        // Message event - handle incoming messages
+        discordClient.on(Events.MessageCreate, async (message) => {
+            // Ignore bot's own messages
+            if (message.author.id === botUserId || message.author.bot) {
+                return;
+            }
+
+            // Only respond in configured channels
+            if (config.discordChannels && !config.discordChannels.includes(message.channel.id)) {
+                return;
+            }
+
+            // Parse message content
+            const text = message.content.trim();
+            const userName = message.author.username;
+            const channelId = message.channel.id;
+
+            logger.info(`[DISCORD] Message from ${userName} in ${message.channel.name}: ${text}`);
+
+            // Handle mentions - Discord bot mentions are <@BOT_ID>
+            let cleanText = text;
+            if (text.includes(`<@${botUserId}>`)) {
+                cleanText = text.replace(`<@${botUserId}>`, '').trim();
+            }
+
+            // Call the message handler (shared with Slack)
+            if (messageHandler) {
+                await messageHandler(cleanText, channelId, userName, 'discord');
+            }
+        });
+
+        // Error handling
+        discordClient.on(Events.Error, (error) => {
+            logger.error('[DISCORD] Client error:', error);
+        });
+
+        // Login to Discord
+        await discordClient.login(config.discordToken);
+        logger.info('🎮 Discord client connecting...');
+
+        return discordClient;
+
+    } catch (error) {
+        logger.error('Failed to initialize Discord:', error);
+        return null;
+    }
+}
+
+async function sendDiscordMessage(channelId, text) {
+    if (!discordClient) {
+        logger.warn('Discord client not initialized');
+        return;
+    }
+
+    try {
+        const channel = await discordClient.channels.fetch(channelId);
+        if (channel && channel.isTextBased()) {
+            await channel.send(text);
+        }
+    } catch (error) {
+        logger.error(`Failed to send Discord message to ${channelId}:`, error);
+    }
+}
+
+function getDiscordClient() {
+    return discordClient;
+}
+
+function getDiscordBotUserId() {
+    return botUserId;
+}
+
+module.exports = {
+    initializeDiscord,
+    sendDiscordMessage,
+    getDiscordClient,
+    getDiscordBotUserId
+};

--- a/index.js
+++ b/index.js
@@ -644,16 +644,7 @@ async function processInput(text, channel, userName, platform = 'slack') {
   }
 }
 
-async function _slackMessage(message, channel_id) {
-  try {
-    await web.chat.postMessage({
-      channel: channel_id,
-      text: message,
-    });
-  } catch (error) {
-    logger.error('Error sending message to Slack: ' + error);
-  }
-}
+// Removed duplicate _slackMessage definition (platform-aware version earlier in file is authoritative)
 
 const userCache = {};
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@slack/rtm-api": "^7.0.4",
     "@slack/web-api": "^7.9.2",
     "@slack/web-api": "^7.12.0",
+    "discord.js": "^14.17.3",
     "nconf": "^0.13.0",
     "sonos": "^1.14.1",
     "urlencode": "^2.0.0",

--- a/slack.js
+++ b/slack.js
@@ -93,6 +93,12 @@ module.exports = function SlackSystem({ botToken, appToken, logger, onCommand })
         web,
         // Helper to send messages
         sendMessage: async (text, channelId, options = {}) => {
+            // Basic heuristic: Slack channel IDs usually start with C, D, G, or W etc.
+            // Discord channel IDs are long numeric strings. Skip if looks like Discord.
+            if (/^[0-9]{17,22}$/.test(channelId)) {
+                logger.debug(`Skipping Slack send for non-Slack channel id: ${channelId}`);
+                return;
+            }
             try {
                 await web.chat.postMessage({
                     channel: channelId,


### PR DESCRIPTION
## Changes
- ✅ Full Discord support alongside Slack
- ✅ Role-based admin permissions for Discord
- ✅ Platform-aware message routing
- ✅ Discord-only mode support
- ✅ Updated documentation (README.md + DISCORD.md)
- ✅ 2000 char limit handling for Discord messages
- ✅ Combined help for Discord admins

## Testing
Tested with both Slack and Discord running simultaneously. All commands working:
- Basic commands (help, add, list, current)
- Voting commands (gong, vote)
- Admin commands (setvolume, pause, play, flush) with role-based permissions

## Breaking Changes
None - fully backward compatible with existing Slack-only setups.

## New Config Fields
- `discordToken`: Discord bot token
- `discordChannels`: Array of channel IDs/names where bot responds
- `discordAdminRoles`: Array of role names/IDs with admin permissions