### PR TITLE
Fix workflow job conditions causing skipped executions

### DIFF
--- a/.github/workflows/feature-request-enhance.yml
+++ b/.github/workflows/feature-request-enhance.yml
@@ -110,7 +110,6 @@ jobs:
   create-confluence:
     runs-on: ubuntu-latest
     needs: preprocess
-    if: needs.preprocess.outcome == 'success'
     permissions:
       contents: read
       issues: write
@@ -191,7 +190,6 @@ jobs:
   update-github-issue:
     runs-on: ubuntu-latest
     needs: preprocess
-    if: needs.preprocess.outcome == 'success'
     permissions:
       contents: read
       issues: write
@@ -244,8 +242,7 @@ jobs:
 
   add-comment:
     runs-on: ubuntu-latest
-    needs: [preprocess, update-github-issue]
-    if: needs.update-github-issue.outcome == 'success'
+    needs: update-github-issue
     permissions:
       issues: write
     steps:


### PR DESCRIPTION
## Problem
After merging PR #205, all dependent jobs (create-confluence, update-github-issue, add-comment) were being skipped even though the preprocess job completed successfully.

Example failed run: https://github.com/htilly/SlackONOS/actions/runs/20369790629

## Root Cause
Using `if: needs.preprocess.outcome == 'success'` causes GitHub Actions to skip jobs incorrectly. GitHub Actions documentation states that dependent jobs automatically skip if their dependencies fail, so explicit conditions are unnecessary and can cause unexpected behavior.

## Solution
Remove the unnecessary `if` conditions:
- ✅ Removed from `create-confluence` job
- ✅ Removed from `update-github-issue` job  
- ✅ Simplified `add-comment` to only depend on `update-github-issue`

## Testing
- Workflow syntax validated locally
- Jobs will now execute when preprocess succeeds
- Jobs will still auto-skip if preprocess fails (GitHub Actions default behavior)

## Impact
- Fixes enhancement workflow to actually update issues
- No breaking changes to existing functionality
- Maintains separation of Confluence as independent job