### PR TITLE
security: close all 18 open Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,21 +10,21 @@
       "license": "ISC",
       "dependencies": {
         "@jsfeb26/urllib-sync": "^1.1.4",
-        "@sefinek/google-tts-api": "^2.1.13",
+        "@sefinek/google-tts-api": "^2.1.15",
         "@simplewebauthn/server": "^13.3.1",
         "@slack/rtm-api": "^7.0.4",
         "@slack/socket-mode": "^2.0.7",
-        "@slack/web-api": "^7.16.0",
+        "@slack/web-api": "^7.17.0",
         "bcrypt": "^6.0.0",
         "discord.js": "^14.26.4",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "mp3-duration": "^1.1.0",
         "nconf": "^0.13.0",
-        "openai": "^6.42.0",
-        "posthog-node": "^5.36.3",
+        "openai": "^6.46.0",
+        "posthog-node": "^5.41.0",
         "selfsigned": "^5.5.0",
         "sonos": "^1.14.3",
-        "soundcraft-ui-connection": "^6.0.3",
+        "soundcraft-ui-connection": "^6.0.4",
         "urlencode": "^2.0.0",
         "winston": "^3.18.3",
         "xml2js": "^0.6.2"
@@ -470,18 +470,18 @@
       }
     },
     "node_modules/@posthog/core": {
-      "version": "1.30.9",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.30.9.tgz",
-      "integrity": "sha512-Cn004VJ7ZWQRaVQG7efh+pMtRMIVZznktngXe5I3E8wClRdMwCZaSa6jo/X04Oc04z8PeMp4GEcWVkdEhmAEXw==",
+      "version": "1.46.9",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.46.9.tgz",
+      "integrity": "sha512-EXO6y5ih+jBkTCpUCuYgQmajuDZuvy6vMvflkub6pLQyi0GPlCPWVSvZZkOeQw9e2MxoD5GteeGCt9R8+UJ/yQ==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/types": "1.381.0"
+        "@posthog/types": "^1.402.2"
       }
     },
     "node_modules/@posthog/types": {
-      "version": "1.381.0",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.381.0.tgz",
-      "integrity": "sha512-AW68BovKFCNbPdq3VjOzfQeSQRYMvQVv+46LDywWFXO/oOTXFKwjY92FaJQSTXWgTNgDpqigCw3yUFDinK3hZA==",
+      "version": "1.402.2",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.402.2.tgz",
+      "integrity": "sha512-ZZTiS4dLwF4/D0YTzS3gGSLFnhuNOY5yu4d9VGS9trGe5GW6FjIXo20p18K5BPW2RZSYSld8sdnSAY3AUXleUQ==",
       "license": "MIT"
     },
     "node_modules/@sapphire/async-queue": {
@@ -518,12 +518,12 @@
       }
     },
     "node_modules/@sefinek/google-tts-api": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/@sefinek/google-tts-api/-/google-tts-api-2.1.13.tgz",
-      "integrity": "sha512-y/u+UsOPdJRdriNFqJwOEjInyHRymp4IwPiZcSyC+qOygAr/3rv2kpBbBcPS0vW/xkLQI3WzDkSWsDs/2R2CWA==",
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@sefinek/google-tts-api/-/google-tts-api-2.1.15.tgz",
+      "integrity": "sha512-StJah6VNfZmeRYkR2AqVBQ6guStp/J9p7+dMbSACr1LcBmhUTEDv2f6paPIvFJfh+4apUE9+oDw2xhM1ZKfTlQ==",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.13.6"
+        "axios": "^1.18.1"
       }
     },
     "node_modules/@simplewebauthn/server": {
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@slack/web-api": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.16.0.tgz",
-      "integrity": "sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.19.0.tgz",
+      "integrity": "sha512-ItjyjEZml+LDH8CjcCLRLJHh7VZtevPKExrRN3l5KWyBliyDnGAeoO4Y+K+fFBmRpKLYVPgqWMX4THldv2HVtA==",
       "license": "MIT",
       "dependencies": {
         "@slack/logger": "^4.0.1",
@@ -817,13 +817,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -865,9 +865,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1855,10 +1855,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2251,15 +2261,27 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.42.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.42.0.tgz",
-      "integrity": "sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==",
+      "version": "6.49.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.49.0.tgz",
+      "integrity": "sha512-aYCc0C6L864eR6WSYIwQGyXriw/nIyZx0ObvhzOEVuk0zoBDpynjSbrionWI7q65B5H8jJX0DXR9snEzM6bfPg==",
       "license": "Apache-2.0",
       "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
         "ws": {
           "optional": true
         },
@@ -2465,12 +2487,12 @@
       }
     },
     "node_modules/posthog-node": {
-      "version": "5.36.3",
-      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.36.3.tgz",
-      "integrity": "sha512-cbAB8w3lJf+rQlxgBVkbQha/yJnt7NFe8l23iE5brLl4YLv10y+Xk6a0SzquZzk5tebznW0qpz3WEUJpf2OI9w==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.48.1.tgz",
+      "integrity": "sha512-BxLX2SqGEQhPqCPTalpyo0RRv1NMbf7UaN7q9d/ED77ksD6XOmE7ko2vIKO8F0zPL1NtKxIi+DYXap9lvR0RaA==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/core": "1.30.9"
+        "@posthog/core": "^1.46.9"
       },
       "engines": {
         "node": "^20.20.0 || >=22.22.0"
@@ -2728,9 +2750,9 @@
       }
     },
     "node_modules/soundcraft-ui-connection": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/soundcraft-ui-connection/-/soundcraft-ui-connection-6.0.3.tgz",
-      "integrity": "sha512-oK6wFdmlKSUVG5voVXNRcBA0iVvnXvcpPQMh2LN/g7ugAX28T5vXN37rkKBgfhdUHgVqFcRxvApZuJtgu0iGJg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/soundcraft-ui-connection/-/soundcraft-ui-connection-6.0.4.tgz",
+      "integrity": "sha512-uvd4KCJP6wBt55jIoUyLkdOGelpC+rytRz7NFf+0CCuDtFH38ap4GmdQvIBs5c9rQ9TsdguFi4AVY8cKOD27Bw==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
@@ -2919,16 +2941,16 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/test-exclude/node_modules/glob": {
@@ -3048,9 +3070,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -35,21 +35,21 @@
   "license": "ISC",
   "dependencies": {
     "@jsfeb26/urllib-sync": "^1.1.4",
-    "@sefinek/google-tts-api": "^2.1.13",
+    "@sefinek/google-tts-api": "^2.1.15",
     "@simplewebauthn/server": "^13.3.1",
     "@slack/rtm-api": "^7.0.4",
     "@slack/socket-mode": "^2.0.7",
-    "@slack/web-api": "^7.16.0",
+    "@slack/web-api": "^7.17.0",
     "bcrypt": "^6.0.0",
     "discord.js": "^14.26.4",
     "lodash": "^4.18.1",
     "mp3-duration": "^1.1.0",
     "nconf": "^0.13.0",
-    "openai": "^6.42.0",
-    "posthog-node": "^5.36.3",
+    "openai": "^6.46.0",
+    "posthog-node": "^5.41.0",
     "selfsigned": "^5.5.0",
     "sonos": "^1.14.3",
-    "soundcraft-ui-connection": "^6.0.3",
+    "soundcraft-ui-connection": "^6.0.4",
     "urlencode": "^2.0.0",
     "winston": "^3.18.3",
     "xml2js": "^0.6.2"
@@ -58,11 +58,12 @@
     "node": ">=22.0.0"
   },
   "overrides": {
-    "axios": "^1.17.0",
+    "axios": "^1.18.1",
     "serialize-javascript": "^7.0.5",
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "form-data": "^4.0.6",
     "diff": "^8.0.3",
-    "ip": "^2.0.1"
+    "ip": "^2.0.1",
+    "js-yaml": "^4.3.1"
   }
 }


### PR DESCRIPTION
## Summary
Closes every currently-open Dependabot security alert (18 total) by bumping the actual vulnerable transitive packages via `overrides`, plus picks up the routine bumps from the still-open dependency PRs.

## Security fixes
- **axios** `^1.17.0` → `^1.18.1` (override): closes 10 alerts (#109, #111–#119)
- **undici** `^7.28.0` → `^7.29.0` (override): closes 5 alerts (#124–#128)
- **js-yaml**: new `^4.3.1` override (mocha pins `^4.1.0`, so it never self-updates): closes 2 alerts (#108, #120). This goes one patch past what PR #304 proposed (4.3.0) — `GHSA-5p4m-2wfm-xmqj` landed after that PR was opened and isn't fixed until 4.3.1.
- **brace-expansion** 2.1.1→2.1.4, 5.0.6→5.0.9 (`npm update`, already permitted by existing `minimatch` ranges, no override needed): closes #110 plus two more advisories `npm audit` flagged that Dependabot hadn't opened a PR for yet (`GHSA-mh99-v99m-4gvg`, `GHSA-rgw5-rvv9-x895`).

## Also included
Routine bumps from the remaining open Dependabot PRs, superseded by this branch:
- `@sefinek/google-tts-api` → 2.1.15 (#301)
- `@slack/web-api` → 7.17.0 (#296)
- `openai` → 6.46.0 (#300)
- `posthog-node` → 5.41.0 (#299)
- `soundcraft-ui-connection` → 6.0.4 (#292)

Once this merges, Dependabot should auto-close #292, #296, #299, #300, #301, #304, #306 as superseded — worth a manual check if it doesn't.

## Out of scope
`ip` SSRF via `sonos` (`GHSA-2p57-rm9w-gvfp`) has no upstream fix (`first_patched_version: null`) and was already reviewed/dismissed on Dependabot in 2024. `npm audit` will still show this one after merge.

## Testing
- `npm audit`: down to just the one unfixable `ip`/`sonos` finding above
- `npm test`: 666/666 passing (one unrelated `auth-handler.test.mjs` timing flake seen once during a background run — confirmed pre-existing on unmodified `master` too, not caused by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)