### PR TITLE
fix(deps): remove unused @jsfeb26/urllib-sync (Dependabot #129)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.3.5",
       "license": "ISC",
       "dependencies": {
-        "@jsfeb26/urllib-sync": "^1.1.4",
         "@sefinek/google-tts-api": "^2.1.15",
         "@simplewebauthn/server": "^13.3.2",
         "@slack/rtm-api": "^7.0.4",
@@ -259,16 +258,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@jsfeb26/urllib-sync": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@jsfeb26/urllib-sync/-/urllib-sync-1.1.4.tgz",
-      "integrity": "sha512-GLlf7+Fd1hbyJHNIaOK+C/E/22WECEaGqJEqmtBgFS45GjNYTRu1pFPqS9l2BJJrN8aSlepzuRc8Nly53FfIdQ==",
-      "license": "MIT",
-      "dependencies": {
-        "urllib": "~2.11.0",
-        "utility": "~1.7.1"
       }
     },
     "node_modules/@levischuck/tiny-cbor": {
@@ -775,15 +764,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/address": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/address/-/address-2.0.3.tgz",
-      "integrity": "sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16.0.0"
-      }
-    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -823,12 +803,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1344,12 +1318,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/copy-to": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/copy-to/-/copy-to-2.0.1.tgz",
-      "integrity": "sha512-3DdaFaU/Zf1AnpLiFDeNCD4TOWe3Zl2RZaTzUvWiIk5ERzcCodOE20Vqq4fzCbNoHURFHT4/us/Lfq+S2zyY4w==",
-      "license": "MIT"
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1395,18 +1363,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/default-user-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/default-user-agent/-/default-user-agent-1.0.0.tgz",
-      "integrity": "sha512-bDF7bg6OSNcSwFWPu4zYKpVkJZQYVrAANMYB8bc9Szem1D0yKdm4sa/rOCs2aC9+2GMqQ7KnwtZRvDhmLF0dXw==",
-      "license": "MIT",
-      "dependencies": {
-        "os-name": "~1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1424,30 +1380,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/digest-header": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/digest-header/-/digest-header-0.0.1.tgz",
-      "integrity": "sha512-Qi0KOZgRnkQJuvMWbs1ZRRajEnbsMU8xlJI4rHIbPC+skHQ30heO5cIHpUFT4jAvAe+zPtdavLSAxASqoyZ3cg==",
-      "license": "MIT",
-      "dependencies": {
-        "utility": "0.1.11"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/digest-header/node_modules/utility": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/utility/-/utility-0.1.11.tgz",
-      "integrity": "sha512-epFsJ71+/yC7MKMX7CM9azP31QBIQhywkiBUj74i/T3Y2TXtEor26QBkat7lGamrrNTr5CBI1imd/8F0Bmqw4g==",
-      "license": "MIT",
-      "dependencies": {
-        "address": ">=0.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/discord-api-types": {
@@ -1573,12 +1505,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1884,15 +1810,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -2177,15 +2094,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -2221,15 +2129,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -2485,37 +2384,6 @@
         "zod": {
           "optional": true
         }
-      }
-    },
-    "node_modules/os-name": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
-      "integrity": "sha512-f5estLO2KN8vgtTRaILIgEGBoBrMnZ3JQ7W9TMZCnOIGwHe8TRGSpcagnWDo+Dfhd/z08k9Xe75hvciJJ8Qaew==",
-      "license": "MIT",
-      "dependencies": {
-        "osx-release": "^1.0.0",
-        "win-release": "^1.0.0"
-      },
-      "bin": {
-        "os-name": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/osx-release": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
-      "integrity": "sha512-ixCMMwnVxyHFQLQnINhmIpWqXIfS2YOXchwQrk+OFzmo6nDjQ0E4KXAyyUh0T0MZgV4bUhkRrAbVqlE4yLVq4A==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.1.0"
-      },
-      "bin": {
-        "osx-release": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/p-cancelable": {
@@ -2964,15 +2832,6 @@
         "node": "*"
       }
     },
-    "node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -3290,70 +3149,11 @@
         "iconv-lite": "~0.6.3"
       }
     },
-    "node_modules/urllib": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/urllib/-/urllib-2.11.1.tgz",
-      "integrity": "sha512-AfsJyOjcK7D1aRXJndBGfsBETstYr8sVZV35W31TZA9bkoV+PADYEBUvYQVnoVu/ReAHHZlrWn44AEd6azwC7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.2.0",
-        "debug": "^2.2.0",
-        "default-user-agent": "^1.0.0",
-        "digest-header": "^0.0.1",
-        "humanize-ms": "^1.2.0",
-        "iconv-lite": "^0.4.13",
-        "media-typer": "^0.3.0",
-        "statuses": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/urllib/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/urllib/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/urllib/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/utility": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/utility/-/utility-1.7.1.tgz",
-      "integrity": "sha512-sRaq0+aGCLPEJUQhIu7/kvPDgWH+LJVx6fBWfmOolJRthctgZdMsg94kwj9RcLevZa9gD6zobrIn/hg74xwPXw==",
-      "license": "MIT",
-      "dependencies": {
-        "copy-to": "~2.0.1",
-        "escape-html": "~1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.12.0"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -3384,27 +3184,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/win-release": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
-      "integrity": "sha512-iCRnKVvGxOQdsKhcQId2PXV1vV3J/sDPXKA4Oe9+Eti2nb2ESEsYHRYls/UjoUW3bIc5ZDO8dTH50A/5iVN+bw==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/win-release/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/winston": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@jsfeb26/urllib-sync": "^1.1.4",
     "@sefinek/google-tts-api": "^2.1.15",
     "@simplewebauthn/server": "^13.3.2",
     "@slack/rtm-api": "^7.0.4",


### PR DESCRIPTION
## Summary
Fixes [Dependabot alert #129](https://github.com/htilly/SlackONOS/security/dependabot/129) — [GHSA-hq3h-g68c-hp78](https://github.com/advisories/GHSA-hq3h-g68c-hp78) / CVE-2026-55553 (high, CVSS 7.5).

`urllib` <= 2.44.0 preserves credential-bearing headers (`Authorization`, `Cookie`, `Proxy-Authorization`, etc.) verbatim when following a cross-origin redirect, which can leak credentials to an untrusted origin.

## Root cause
`@jsfeb26/urllib-sync` (pinned to `~2.11.0`, added in 2021) was the only dependency pulling in the vulnerable `urllib@2.11.1`. A repo-wide search found **no references to it anywhere in the codebase** — it's dead weight.

## Fix
Removed `@jsfeb26/urllib-sync` from `package.json` and regenerated `package-lock.json`. This drops the vulnerable transitive `urllib` entirely, rather than forcing a version override against its tight semver pin.

## Verification
- `npm install` — no `urllib` package remains in the lockfile
- `npm test` — all 745 tests pass
- `npm audit` — remaining findings (`ip`/SSRF via `sonos`) are pre-existing and unrelated to this alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)