### PR TITLE
chore: gitignore .security-review/ scan output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ docker-compose.override.yml
 # ===================================================================
 test/config/test-config.json
 test/timing-log.json
+
+# ===================================================================
+# Security review scan output (repo-security-review skill / /security-review)
+# ===================================================================
+.security-review/


### PR DESCRIPTION
The `repo-security-review` skill's working directory (`.security-review/` — phase JSON outputs, `final-report.md`) was previously being deleted by hand after a review. Ignoring it instead means it survives as a local reference without ever risking being committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)